### PR TITLE
8N2 config added for Posix; 8E1, 8O1 and 8N2 added for Windows

### DIFF
--- a/src/sniff_posix.c
+++ b/src/sniff_posix.c
@@ -79,6 +79,12 @@ void serial_open(BAUD_RESOURCE *res, int speed) {
     fdt.c_cflag &= ~CSTOPB;
     fdt.c_cflag &= ~CSIZE;
     fdt.c_cflag |= CS8;
+  } else if (strcmp(res->config, "8N2") == 0) {
+    fdt.c_cflag |= CS8;
+    fdt.c_cflag &= ~PARENB;
+    fdt.c_cflag |= CSTOPB;
+    fdt.c_cflag &= ~CSIZE;
+    fdt.c_cflag |= CS8;
   } else if (strcmp(res->config, "8E1") == 0) {
     fdt.c_cflag |= CS8;
     fdt.c_cflag |= PARENB;

--- a/src/sniff_winnt.c
+++ b/src/sniff_winnt.c
@@ -58,6 +58,16 @@ void serial_open(BAUD_RESOURCE *res, int speed) {
   if (strcmp(res->config, "8N1") == 0) {
     dcb.ByteSize = 8;
     dcb.Parity = NOPARITY;
+  } else if (strcmp(res->config, "8N2") == 0) {
+    dcb.ByteSize = 8;
+    dcb.Parity = NOPARITY;
+    dcb.StopBits = TWOSTOPBITS;
+  } if (strcmp(res->config, "8E1") == 0) {
+    dcb.ByteSize = 8;
+    dcb.Parity = EVENPARITY;
+  } if (strcmp(res->config, "8O1") == 0) {
+    dcb.ByteSize = 8;
+    dcb.Parity = ODDPARITY;
   } else if (strcmp(res->config, "7E1") == 0) {
     dcb.ByteSize = 7;
     dcb.Parity = EVENPARITY;


### PR DESCRIPTION
For Modbus no parity, we require 2 stop bits.