### PR TITLE
Fix receiver side in 8N2 mode

### DIFF
--- a/src/sniff_posix.c
+++ b/src/sniff_posix.c
@@ -79,12 +79,14 @@ void serial_open(BAUD_RESOURCE *res, int speed) {
     fdt.c_cflag &= ~CSTOPB;
     fdt.c_cflag &= ~CSIZE;
     fdt.c_cflag |= CS8;
+    fdt.c_iflag &= ~INPCK;
   } else if (strcmp(res->config, "8N2") == 0) {
     fdt.c_cflag |= CS8;
     fdt.c_cflag &= ~PARENB;
     fdt.c_cflag |= CSTOPB;
     fdt.c_cflag &= ~CSIZE;
     fdt.c_cflag |= CS8;
+    fdt.c_iflag &= ~INPCK;
   } else if (strcmp(res->config, "8E1") == 0) {
     fdt.c_cflag |= CS8;
     fdt.c_cflag |= PARENB;


### PR DESCRIPTION
The 8N2 mode didn't seem to be working, I think this flag fixes it.